### PR TITLE
mods to token revoke

### DIFF
--- a/test/OAuth2/ResponseType/AccessTokenTest.php
+++ b/test/OAuth2/ResponseType/AccessTokenTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace OAuth2\ResponseType;
+
+use OAuth2\Server;
+use OAuth2\Storage\Memory;
+
+class AccessTokenTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRevokeAccessTokenWithTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'access_token');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithoutTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke', 'refresh_token');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithoutTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithRefreshTokenTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'refresh_token');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeAccessTokenWithBogusTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'access_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getAccessToken('revoke'));
+        $accessToken = new AccessToken($tokenStorage);
+        $accessToken->revokeToken('revoke', 'foo');
+        $this->assertFalse($tokenStorage->getAccessToken('revoke'));
+    }
+
+    public function testRevokeRefreshTokenWithBogusTypeHint()
+    {
+        $tokenStorage = new Memory(array(
+            'refresh_tokens' => array(
+                'revoke' => array('mytoken'),
+            ),
+        ));
+
+        $this->assertEquals(array('mytoken'), $tokenStorage->getRefreshToken('revoke'));
+        $accessToken = new AccessToken(new Memory, $tokenStorage);
+        $accessToken->revokeToken('revoke', 'foo');
+        $this->assertFalse($tokenStorage->getRefreshToken('revoke'));
+    }
+}

--- a/test/OAuth2/Storage/AccessTokenTest.php
+++ b/test/OAuth2/Storage/AccessTokenTest.php
@@ -56,7 +56,7 @@ class AccessTokenTest extends BaseTest
     }
 
     /** @dataProvider provideStorage */
-    public function testRevokeAccessToken(AccessTokenInterface $storage)
+    public function testUnsetAccessToken(AccessTokenInterface $storage)
     {
         if ($storage instanceof NullStorage || !method_exists($storage, 'unsetAccessToken')) {
             $this->markTestSkipped('Skipped Storage: ' . $storage->getMessage());


### PR DESCRIPTION
cleans up `AccessToken::revokeToken` and adds tests
